### PR TITLE
Hotfix to force measurement's run dict initializer to check for equal…

### DIFF
--- a/code/measurement.py
+++ b/code/measurement.py
@@ -84,6 +84,8 @@ class Measurement():
                 run_parameters_dict = json.load(run_params_json)
             unsorted_run_parameters_list = [(int(key), run_parameters_dict[key]) for key in run_parameters_dict]
             run_parameters_list = [f[1] for f in sorted(unsorted_run_parameters_list, key = lambda x: x[0])]
+            if len(sorted_run_ids_list) != len(run_parameters_dict):
+                raise RuntimeError("Saved breadboard parameters do not match run_ids in measurement folder.")
             for run_id in sorted_run_ids_list:
                 if not str(run_id) in run_parameters_dict:
                     raise RuntimeError("Saved breadboard parameters do not match run_ids in measurement folder.")


### PR DESCRIPTION
…ity between run ids in folder and in saved dict, not just inclusion of the former in the latter