### PR TITLE
Live analysis race fixes

### DIFF
--- a/code/loading_functions.py
+++ b/code/loading_functions.py
@@ -41,7 +41,7 @@ def _load_json_with_retries(pathname):
         try:
             with open(pathname, 'r') as json_file:
                 return json.load(json_file)
-        except json.JSONDecodeError as e:
+        except (json.JSONDecodeError, OSError) as e:
             print("Got error")
             counter += 1
             if counter < PATIENCE:

--- a/code/measurement.py
+++ b/code/measurement.py
@@ -104,7 +104,11 @@ class Measurement():
         for image_filename in image_filenames_list:
             run_id = Measurement._parse_run_id_from_filename(image_filename)
             if not run_id in unique_run_ids_list:
-                unique_run_ids_list.append(run_id)
+                for other_filename in image_filenames_list:
+                    if str(run_id) in other_filename and TEMP_FILE_MARKER in other_filename:
+                        break
+                else:
+                    unique_run_ids_list.append(run_id)
         return unique_run_ids_list
             
 

--- a/code/measurement.py
+++ b/code/measurement.py
@@ -123,7 +123,7 @@ class Measurement():
 
 
     def _update_runs_dict(self):
-        RUN_MISMATCH_PATIENCE_TIME_SECS = 10
+        RUN_MISMATCH_PATIENCE_TIME_SECS = 20
         matched_run_ids_and_parameters_list = self._get_run_ids_and_parameters_from_measurement_folder()
         for run_id_and_parameters in matched_run_ids_and_parameters_list:
             run_id, parameters = run_id_and_parameters
@@ -194,8 +194,9 @@ class Measurement():
                     self.measurement_analysis_results = Measurement._undigest_analysis_results(dump_dict[key]) 
                 else:
                     run_id_as_integer = int(key)
-                    current_run = self.runs_dict[run_id_as_integer] 
-                    current_run.analysis_results = Measurement._undigest_analysis_results(dump_dict[key])
+                    if run_id_as_integer in self.runs_dict:
+                        current_run = self.runs_dict[run_id_as_integer] 
+                        current_run.analysis_results = Measurement._undigest_analysis_results(dump_dict[key])
 
 
     @staticmethod 

--- a/code/measurement.py
+++ b/code/measurement.py
@@ -20,6 +20,9 @@ FILENAME_DATETIME_FORMAT_STRING = "%Y-%m-%d--%H-%M-%S"
 PARAMETERS_DATETIME_FORMAT_STRING = "%Y-%m-%dT%H:%M:%SZ"
 PARAMETERS_RUN_TIME_NAME = "runtime"
 FILENAME_DELIMITER_CHAR = "_"
+TEMP_FILE_MARKER = "TEMP"
+
+RUN_MISMATCH_PATIENCE_TIME_SECS = 30
 
 class Measurement():
 
@@ -61,7 +64,7 @@ class Measurement():
         self.badshot_function = badshot_function
         self.badshot_checked_list = []
         self.runs_dict = {}
-        self._initialize_runs_dict()
+        self._update_runs_dict()
         if analyses_list is None:
             self.analyses_list = []
         self.measurement_analysis_results = {}
@@ -70,14 +73,6 @@ class Measurement():
 
     def set_badshot_function(self, badshot_function):
         self.badshot_function = badshot_function
-
-    """Initializes the runs dict.
-    
-    Creates a dictionary {run_id:Run} of runs in the measurement. Each individual run is an object containing the run parameters and images."""
-    def _initialize_runs_dict(self):
-        matched_run_ids_and_parameters_list = self._get_run_ids_and_parameters_from_measurement_folder()
-        for run_id_and_parameters in matched_run_ids_and_parameters_list:
-            self._add_run(run_id_and_parameters)
 
 
     def _get_run_ids_and_parameters_from_measurement_folder(self):
@@ -89,7 +84,7 @@ class Measurement():
         else:
             raise RuntimeError("""Drawing parameters directly from breadboard is deprecated. You may use ImageWatchdog.get_run_metadata()
                                 to generate a run params json for legacy datasets.""")
-        unique_run_ids_list = list(set([Measurement._parse_run_id_from_filename(f) for f in os.listdir(self.measurement_directory_path) if self.image_format in f]))
+        unique_run_ids_list = self._get_unique_run_ids_from_folder()
         sorted_run_ids_list = sorted(unique_run_ids_list)
         matched_run_ids_and_parameters_list = []
         #O(n^2) naive search, but it's fine...
@@ -99,8 +94,21 @@ class Measurement():
                     matched_run_ids_and_parameters_list.append((run_id, parameters))
                     break
             else:
-                raise RuntimeError("Unable to find data for run id: " + str(run_id))
+                warnings.warn("Unable to find data for run id: " + str(run_id))
         return matched_run_ids_and_parameters_list
+
+
+    def _get_unique_run_ids_from_folder(self):
+        image_filenames_list = [f for f in os.listdir(self.measurement_directory_path) if self.image_format in f]
+        unique_run_ids_list = []
+        for image_filename in image_filenames_list:
+            run_id = Measurement._parse_run_id_from_filename(image_filename)
+            if not run_id in unique_run_ids_list:
+                unique_run_ids_list.append(run_id)
+        return unique_run_ids_list
+            
+
+
 
     def _add_run(self, run_id_and_parameters):
         run_id, run_parameters = run_id_and_parameters
@@ -109,6 +117,8 @@ class Measurement():
         for run_id_image_filename in run_id_image_filenames:
             for image_name in MEASUREMENT_IMAGE_NAME_DICT[self.imaging_type]:
                 if image_name in run_id_image_filename:
+                    if TEMP_FILE_MARKER in run_id_image_filename:
+                        raise RuntimeError("The following run image is still loading: {0}".format(run_id_image_filename))
                     run_id_image_pathname = os.path.join(self.measurement_directory_path, run_id_image_filename)
                     run_image_pathname_dict[image_name] = run_id_image_pathname 
                     break
@@ -121,9 +131,10 @@ class Measurement():
         self.runs_dict[run_id] = generated_run
 
 
-
+    """
+    Scans the measurement folder for new runs to add to self.runs_dict; 
+    ignores errors from runs more recent than some given time, to avoid issues with live analysis."""
     def _update_runs_dict(self):
-        RUN_MISMATCH_PATIENCE_TIME_SECS = 20
         matched_run_ids_and_parameters_list = self._get_run_ids_and_parameters_from_measurement_folder()
         for run_id_and_parameters in matched_run_ids_and_parameters_list:
             run_id, parameters = run_id_and_parameters

--- a/tests/test_measurement.py
+++ b/tests/test_measurement.py
@@ -46,27 +46,6 @@ class TestMeasurement:
         my_measurement = TestMeasurement.initialize_measurement() 
         assert True
 
-    @staticmethod 
-    def test_initialize_runs_dict():
-        my_measurement = TestMeasurement.initialize_measurement() 
-        my_measurement._initialize_runs_dict()
-        my_runs_dict = my_measurement.runs_dict
-        assert list(my_runs_dict)[0] == TEST_IMAGE_RUN_ID
-        my_run = my_runs_dict[TEST_IMAGE_RUN_ID]
-        my_run_image = my_run.get_image('Side')
-        my_run_params = my_run.get_parameters()
-        my_run_params_bytes = json.dumps(my_run_params).encode("ASCII")
-        assert check_sha_hash(my_run_image.data.tobytes(), TEST_IMAGE_ARRAY_SHA_256_HEX_STRING)
-        assert check_sha_hash(my_run_params_bytes, RUN_PARAMS_SHA_CHECKSUM)
-        my_measurement_params_from_dump = Measurement(measurement_directory_path = TEST_MEASUREMENT_DIRECTORY_PATH, imaging_type = "side_low_mag")
-        my_measurement_params_from_dump._initialize_runs_dict()
-        assert list(my_runs_dict)[0] == TEST_IMAGE_RUN_ID 
-        my_run = my_runs_dict[TEST_IMAGE_RUN_ID]
-        my_run_params = my_run.get_parameters() 
-        my_run_params_bytes = json.dumps(my_run_params).encode("ASCII") 
-        assert check_sha_hash(my_run_params_bytes, RUN_PARAMS_SHA_CHECKSUM)
-
-
     @staticmethod
     def test_update_runs_dict():
         my_measurement = TestMeasurement.initialize_measurement()
@@ -108,7 +87,6 @@ class TestMeasurement:
         VALUE_NAME_TO_CHECK = "id"
         EXPECTED_VALUES = np.array([TEST_IMAGE_RUN_ID])
         my_measurement = TestMeasurement.initialize_measurement() 
-        my_measurement._initialize_runs_dict()
         values = my_measurement.get_parameter_value_from_runs("id")
         assert np.array_equal(values, EXPECTED_VALUES)
         #Test run filtering
@@ -129,7 +107,6 @@ class TestMeasurement:
         VALUE = 3 
         VALUE_AS_ARRAY = np.array([3])
         my_measurement = TestMeasurement.initialize_measurement() 
-        my_measurement._initialize_runs_dict()
         for run_id in my_measurement.runs_dict:
             current_run = my_measurement.runs_dict[run_id] 
             current_run.analysis_results[VALUE_NAME_TO_CHECK] = VALUE 
@@ -153,7 +130,6 @@ class TestMeasurement:
         VALUE_AS_ARRAY = np.array([VALUE])
         EXPECTED_PARAMS = np.array([TEST_IMAGE_RUN_ID])
         my_measurement = TestMeasurement.initialize_measurement() 
-        my_measurement._initialize_runs_dict()
         for run_id in my_measurement.runs_dict:
             current_run = my_measurement.runs_dict[run_id] 
             current_run.analysis_results[VALUE_NAME_TO_CHECK] = VALUE 
@@ -197,7 +173,6 @@ class TestMeasurement:
         VALUE_1_AS_LIST = [1] 
         VALUE_2_AS_LIST = [2]
         my_measurement = TestMeasurement.initialize_measurement() 
-        my_measurement._initialize_runs_dict()
         def analysis_func_1(my_measurement, my_run):
             return (VALUE_1,)
         def analysis_func_2(my_measurement, my_run):
@@ -282,7 +257,6 @@ class TestMeasurement:
     @staticmethod
     def test_set_box():
         my_measurement = TestMeasurement.initialize_measurement() 
-        my_measurement._initialize_runs_dict() 
         box_coordinates = [1, 2, 3, 4]
         my_measurement.set_box('foo', box_coordinates = box_coordinates)
         assert my_measurement.measurement_parameters['foo'] == box_coordinates


### PR DESCRIPTION
Fixes to protect against race conditions when running live analysis. These include:

Protecting against OSErrors in load_json_with_retries
Supporting TEMP files for run images that are in the process of being move 
Increasing the patience window where the lack of matching run ids is tolerated
Raising a warning, rather than throwing an error, when a present run image doesn't have information in the dump json