### PR TITLE
Slight tweak to image unpacking in _roi_crop_helper for compatibility…

### DIFF
--- a/code/image_processing_functions.py
+++ b/code/image_processing_functions.py
@@ -74,7 +74,9 @@ def _roi_crop_helper(image_stack, ROI = None, rebin_pixel_num = None):
         image_stack = image_stack[:, roi_y_min:roi_y_max, roi_x_min:roi_x_max]
     if not rebin_pixel_num is None:
         image_stack = bin_and_average_data(image_stack, rebin_pixel_num, omitted_axes = 0)
-    image_with_atoms, image_without_atoms, image_dark = image_stack
+    image_with_atoms = image_stack[0] 
+    image_without_atoms = image_stack[1] 
+    image_dark = image_stack[2]
     return (safe_subtract(image_with_atoms, image_dark),  safe_subtract(image_without_atoms, image_dark))
 
 """


### PR DESCRIPTION
… with legacy datasets

Some legacy datasets have more than three images saved in .fits data files. While this behavior is to be eliminated going forward, need to support pre-existing datasets. Fortunately, all this requires is changing the unpacking syntax for the individual images from the numpy array that's loaded from .fits files to explicitly only take the first three elements.